### PR TITLE
feat: add SSL configuration required for remote redis cache

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,10 @@ The build cache takes the following options:
 |net.idlestate.gradle.caching.redis.ttl
 |14400 (10 days in minutes)
 
+|ssl
+|net.idlestate.gradle.caching.redis.ssl
+|false
+
 |===
 
 ## Usage
@@ -88,6 +92,7 @@ buildCache {
         host = '127.0.0.1'
         port = 6379
         timeToLive = 2*24*60 // two days in minutes
+        ssl = false // no SSL for localhost
         enabled = true
         push = true
     }

--- a/README.adoc
+++ b/README.adoc
@@ -48,7 +48,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.idlestate:gradle-redis-build-cache:1.3.0'
+        classpath 'net.idlestate:gradle-redis-build-cache:1.4.0'
     }
 }
 
@@ -74,7 +74,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.idlestate:gradle-redis-build-cache:1.3.0'
+        classpath 'net.idlestate:gradle-redis-build-cache:1.4.0'
     }
 }
 
@@ -92,7 +92,7 @@ buildCache {
         host = '127.0.0.1'
         port = 6379
         timeToLive = 2*24*60 // two days in minutes
-        ssl = false // no SSL for localhost
+        ssl = false // no SSL for localhost - default: false
         enabled = true
         push = true
     }
@@ -112,7 +112,7 @@ initscript {
     }
 
     dependencies {
-        classpath 'net.idlestate:gradle-redis-build-cache:1.3.0'
+        classpath 'net.idlestate:gradle-redis-build-cache:1.4.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'net.idlestate'
-version = '1.3.0'
+version = '1.4.0'
 
 repositories {
     mavenCentral()

--- a/examples/init/init-build-cache.gradle
+++ b/examples/init/init-build-cache.gradle
@@ -7,7 +7,7 @@ initscript {
     }
 
     dependencies {
-        classpath 'net.idlestate:gradle-redis-build-cache:1.3.0'
+        classpath 'net.idlestate:gradle-redis-build-cache:1.4.0'
     }
 }
 

--- a/examples/plugin/settings.gradle
+++ b/examples/plugin/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.idlestate:gradle-redis-build-cache:1.3.0'
+        classpath 'net.idlestate:gradle-redis-build-cache:1.4.0'
     }
 }
 

--- a/examples/settings/settings.gradle
+++ b/examples/settings/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.idlestate:gradle-redis-build-cache:1.3.0'
+        classpath 'net.idlestate:gradle-redis-build-cache:1.4.0'
     }
 }
 
@@ -25,6 +25,7 @@ buildCache {
         host = '127.0.0.1'
         port = 6379
         timeToLive = 2*24*60 // two days in minutes
+        ssl = false // no SSL for localhost - default: false
         enabled = true
         push = true
     }

--- a/src/main/java/net/idlestate/gradle/caching/RedisBuildCache.java
+++ b/src/main/java/net/idlestate/gradle/caching/RedisBuildCache.java
@@ -23,12 +23,14 @@ import org.gradle.caching.configuration.AbstractBuildCache;
 public class RedisBuildCache extends AbstractBuildCache {
     private static final int DEFAULT_PORT = 6379;
     private static final int DEFAULT_TIME_TO_LIVE = 10 * 24 * 60; // 10 days as minutes
+    private static final boolean DEFAULT_SSL = false;
 
     private String _host = System.getProperty( "net.idlestate.gradle.caching.redis.host", "localhost" );
     private int _port = getDefaultPort();
     private String _password = System.getProperty( "net.idlestate.gradle.caching.redis.password", null );
 
     private int _timeToLive = getDefaultTimeToLive();
+    private boolean _ssl = Boolean.parseBoolean( System.getProperty( "net.idlestate.gradle.caching.redis.ssl", Boolean.toString( DEFAULT_SSL ) ) );
 
     private static int getDefaultPort() {
         final String port = System.getProperty( "net.idlestate.gradle.caching.redis.port", Integer.toString( DEFAULT_PORT ) );
@@ -93,5 +95,16 @@ public class RedisBuildCache extends AbstractBuildCache {
 
     public void setTimeToLive( final int timeToLive ) {
         _timeToLive = timeToLive;
+    }
+
+    /**
+     * @return SSL - default: false.
+     */
+    public boolean getSSL() {
+        return _ssl;
+    }
+
+    public void setSSL( final boolean ssl ) {
+        _ssl = ssl;
     }
 }

--- a/src/main/java/net/idlestate/gradle/caching/RedisBuildCacheService.java
+++ b/src/main/java/net/idlestate/gradle/caching/RedisBuildCacheService.java
@@ -52,8 +52,8 @@ public class RedisBuildCacheService implements BuildCacheService {
     private final JedisPool _jedisPool;
     private final int _timeToLive;
 
-    RedisBuildCacheService( final String host, final int port, final String password, final int timeToLive ) {
-        _jedisPool = new JedisPool( new JedisPoolConfig(), host, port, Protocol.DEFAULT_TIMEOUT, password );
+    RedisBuildCacheService( final String host, final int port, final String password, final int timeToLive, final boolean ssl ) {
+        _jedisPool = new JedisPool( new JedisPoolConfig(), host, port, Protocol.DEFAULT_TIMEOUT, password, ssl );
         _timeToLive = timeToLive * 60;
     }
 

--- a/src/main/java/net/idlestate/gradle/caching/RedisBuildCacheServiceFactory.java
+++ b/src/main/java/net/idlestate/gradle/caching/RedisBuildCacheServiceFactory.java
@@ -30,8 +30,9 @@ public class RedisBuildCacheServiceFactory implements BuildCacheServiceFactory<R
                 .config( "host", configuration.getHost() )
                 .config( "port", Integer.toString( configuration.getPort() ) )
                 .config( "password", configuration.getPassword() == null ? "<without password>" : "<password given>" )
-                .config( "ttl", Integer.toString( configuration.getTimeToLive() ) );
+                .config( "ttl", Integer.toString( configuration.getTimeToLive() ) )
+                .config( "ssl", Boolean.toString( configuration.getSSL() ) );
 
-        return new RedisBuildCacheService( configuration.getHost(), configuration.getPort(), configuration.getPassword(), configuration.getTimeToLive() );
+        return new RedisBuildCacheService( configuration.getHost(), configuration.getPort(), configuration.getPassword(), configuration.getTimeToLive(), configuration.getSSL() );
     }
 }


### PR DESCRIPTION
This is required to connect to the redis/valkey backend managed remotely on Cloud like AWS.